### PR TITLE
Enable puppet4

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,0 +1,3 @@
+fixtures:
+  symlinks:
+    external_facts: "#{source_dir}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+.ruby-version
+.ruby-gemset
+Gemfile.lock
+pkg

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['>= 3.3']
+gem 'puppet', puppetversion
+gem 'puppetlabs_spec_helper', '>= 0.8.2'
+gem 'puppet-lint', '>= 1.0.0'
+gem 'facter', '>= 1.7.0'
+gem 'rspec'
+gem 'rspec-puppet'

--- a/README.md
+++ b/README.md
@@ -26,9 +26,13 @@ automatically purged and will become absent in subsequent puppet runs.
 
 #### Enabling Support
 
-Hosts must declare the directory management portion of the module
+Hosts must declare the directory management portion of the module if
+they want non-existant facts to be purged and no facts are being pushed.
 
     include ::external_facts
+
+NOTE: As long as there is at least one fact being created auto-purging
+of other non-manged facts will occur even if the base class is not included
 
 #### Creating facts
 
@@ -45,10 +49,5 @@ or may be declared with an explicit value for use elsewhere
 ## Limitations
 
 This module should work on all GNU Linux systems, but has only been tested
-on Ubuntu.
+on Ubuntu and RedHat.
 
-Puppet Enterprise deployments are not supported at present.
-
-## Testing
-
-There is no unit testing provided.

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,20 @@
+require 'rubygems'
+require 'puppetlabs_spec_helper/rake_tasks'
+require 'puppet-lint/tasks/puppet-lint'
+PuppetLint.configuration.send('disable_80chars')
+PuppetLint.configuration.ignore_paths = ["spec/**/*.pp", "pkg/**/*.pp"]
+
+desc "Validate manifests, templates, and ruby files"
+task :validate do
+  Dir['manifests/**/*.pp'].each do |manifest|
+    sh "puppet parser validate --noop #{manifest}"
+  end
+  Dir['spec/**/*.rb','lib/**/*.rb'].each do |ruby_file|
+    sh "ruby -c #{ruby_file}" unless ruby_file =~ /spec\/fixtures/
+  end
+  Dir['templates/**/*.erb'].each do |template|
+    sh "erb -P -x -T '-' #{template} | ruby -c"
+  end
+end
+
+task :default => [:validate, :spec, :lint]

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -20,15 +20,15 @@
 define external_facts::fact (
   $value = true,
 ) {
-  include external_facts::params
+  include external_facts
 
-  file { "${facter_basedir}/${title}.txt":
+  file { "fact ${title}":
     ensure  => file,
+    path    => "${external_facts::facts_dir}/${title}.txt",
     owner   => 'root',
     group   => 'root',
     mode    => '0644',
     content => "${title}=${value}",
     require => Class['external_facts'],
   }
-
 }

--- a/manifests/fact.pp
+++ b/manifests/fact.pp
@@ -20,8 +20,9 @@
 define external_facts::fact (
   $value = true,
 ) {
+  include external_facts::params
 
-  file { "/etc/facter/facts.d/${title}.txt":
+  file { "${facter_basedir}/${title}.txt":
     ensure  => file,
     owner   => 'root',
     group   => 'root',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,12 +16,13 @@ class external_facts inherits external_facts::params {
     mode   => '0755',
   }
 
-  file { $external_facts::params::facter_basedir:
+  file { 'facter basedir':
+    path =>  $external_facts::params::facter_basedir,
   } ->
 
-  file { $external_facts::params::facts_dir:
+  file { 'facts dir':
+    path    => $external_facts::params::facts_dir,
     recurse => true,
     purge   => true,
   }
-
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -7,7 +7,7 @@
 #
 # include ::external_facts
 #
-class external_facts {
+class external_facts inherits external_facts::params {
 
   File {
     ensure => directory,
@@ -16,10 +16,10 @@ class external_facts {
     mode   => '0755',
   }
 
-  file { '/etc/facter':
+  file { $external_facts::params::facter_basedir:
   } ->
 
-  file { '/etc/facter/facts.d':
+  file { $external_facts::params::facts_dir:
     recurse => true,
     purge   => true,
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,24 @@
+# == Class: external_facts::params
+#
+# Defines the common params used by Class[external_facts]
+#
+# === Authors
+#
+# Andrew J Grimberg <agrimberg@linuxfoundation.org>
+#
+# === Copyright
+#
+# Copyright 2015 Andrew J Grimberg
+#
+class external_facts::params {
+  if ($::is_pe or versioncmp($::puppetversion, '4.0.0') >= 0 {
+    # PE and Puppet4+ use the same paths
+    $facter_basedir = "${::settings::environmentpath}/facter"
+  }
+  else {
+    # All pre Puppet4+ FOSS distributions
+    $facter_basedir = '/etc/facter'
+  }
+
+  $facts_dir = "${facter_basedir}/facts.d"
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,9 +11,9 @@
 # Copyright 2015 Andrew J Grimberg
 #
 class external_facts::params {
-  if ($::is_pe or versioncmp($::puppetversion, '4.0.0') >= 0 {
+  if ($::is_pe or versioncmp($::puppetversion, '4.0.0') >= 0) {
     # PE and Puppet4+ use the same paths
-    $facter_basedir = "${::settings::environmentpath}/facter"
+    $facter_basedir = '/etc/puppetlabs/facter'
   }
   else {
     # All pre Puppet4+ FOSS distributions

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -1,0 +1,72 @@
+require 'spec_helper'
+describe 'external_facts' do
+  context 'FOSS < 4.0' do
+    let(:facts) {
+      {
+        :is_pe         => false,
+        :puppetversion => '2.7.1'
+      }
+    }
+
+    it { should contain_class('external_facts') }
+    it { should contain_class('external_facts::params') }
+
+    it { should contain_file('facter basedir').with(
+      'path' => '/etc/facter',
+    ) }
+    it { should contain_file('facts dir').with(
+      'path'    => '/etc/facter/facts.d',
+      'recurse' => true,
+      'purge'   => true,
+    ) }
+  end
+
+  context 'FOSS >= 4.0' do
+    let(:settings) {
+      {
+        :environmentpath => '/etc/puppetlabs'
+      }
+    }
+    let(:facts) {
+      {
+        :is_pe         => false,
+        :puppetversion => '4.2.1',
+      }
+    }
+
+    it { should contain_file('facter basedir').with(
+      'path' => '/etc/puppetlabs/facter',
+    ) }
+    it { should contain_file('facts dir').with(
+      'path'    => '/etc/puppetlabs/facter/facts.d',
+      'recurse' => true,
+      'purge'   => true,
+    ) }
+  end
+
+  context 'PE' do
+    let(:settings) {
+      {
+        :environmentpath => '/etc/puppetlabs'
+      }
+    }
+    let(:facts) {
+      {
+        :is_pe         => true,
+        :pe_version    => '3.8.1',
+        :puppetversion => '3.8.1 (Puppet Enterprise 3.8.1)',
+      }
+    }
+
+    it { should contain_file('facter basedir').with(
+      'path' => '/etc/puppetlabs/facter',
+    ) }
+    it { should contain_file('facts dir').with(
+      'path'    => '/etc/puppetlabs/facter/facts.d',
+      'recurse' => true,
+      'purge'   => true,
+    ) }
+  end
+end
+
+# vim: ts=2 sw=2 sts=2 et :

--- a/spec/classes/params_spec.rb
+++ b/spec/classes/params_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+describe 'external_facts::params' do
+  # Testing this class doesn't matter if it's PE or not since we can't
+  # inspect variables just manifest
+  let(:facts) {
+    {
+      :is_pe => true
+    }
+  }
+
+  context 'with defaults for all parameters' do
+    it { should contain_class('external_facts::params') }
+  end
+end
+
+# vim: ts=2 sw=2 sts=2 et :

--- a/spec/defines/fact_spec.rb
+++ b/spec/defines/fact_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+describe 'external_facts::fact', :type => :define do
+  # We've tested that the facts.d gets set correctly in the init_spec so
+  # we'll only test the resultant path on a FOSS Puppet < 4 configuration
+  let(:facts) {
+    {
+      :is_pe         => false,
+      :puppetversion => '2.7.1',
+    }
+  }
+  let(:title) { 'testing' }
+
+  context 'with defaults for all parameters' do
+    let (:params) {{}}
+
+    it { should contain_class('external_facts') }
+
+    it { should contain_file('fact testing').with(
+      'ensure'  => 'file',
+      'path'    => '/etc/facter/facts.d/testing.txt',
+      'owner'   => 'root',
+      'group'   => 'root',
+      'mode'    => '0644',
+      'content' => 'testing=true',
+    ) }
+  end
+end
+
+# vim: ts=2 sw=2 sts=2 et :
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+at_exit { RSpec::Puppet::Coverage.report! }


### PR DESCRIPTION
This patch series enables the use of this module on Puppet 4 systems as well as Puppet Enterprise (they use the same path). It will continue to operate properly on FOSS Puppet < 4.

It also adds in unit tests.
